### PR TITLE
Load all selected patterns, not only first one

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Run
 ```
 ansible-playbook -e@aap.yml -e seed_usecase=rhel seed_portal_content.yml
 ansible-playbook -e@aap.yml -e seed_usecase=network seed_portal_content.yml
+ansible-playbook -e@aap.yml -e seed_usecase='{"rhel","network"}' seed_portal_content.yml
 ```
 
 ## Prepare execution environment

--- a/seed_portal_content.yml
+++ b/seed_portal_content.yml
@@ -42,6 +42,6 @@
 
         - name: Load patterns
           ansible.builtin.include_tasks: load_pattern.yml
-          loop: '{{ patterns.results[0].files }}'
+          loop: "{{ patterns.results | sum(attribute='files', start=[]) }}"
           loop_control:
             loop_var: pattern


### PR DESCRIPTION
When multiple patterns were selected, only the first one was loaded, remaining one were silently ignored.
PR loads all selected patterns.