### PR TITLE
Update usecase urls to official one

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,8 +2,14 @@
 controller_dependency_check: false
 usecases:
   - name: rhel
-    url: https://github.com/craig-br/portal_experience_demo
-    version: feature-rhel-aa
+    url: https://github.com/ansible-collections/community.rhel_ops
+    version: main
   - name: network
-    url: https://github.com/Spredzy/experience_demo_2
+    url: https://github.com/redhat-cop/network.backup
+    version: main
+  - name: windows
+    url: https://github.com/redhat-cop/infra.windows_ops
+    version: main
+  - name: cloud
+    url: https://github.com/redhat-cop/cloud.aws_ops
     version: main


### PR DESCRIPTION
The `group_vars/all.yml` file is used only during local testing (run `ansible-playbook` via cli). Still it is nice to have correct URLs there.